### PR TITLE
Random Lisk Peer

### DIFF
--- a/client/app/src/network/NetworkService.js
+++ b/client/app/src/network/NetworkService.js
@@ -12,7 +12,9 @@
 
     var lisk=require('lisk-js');
 
-    var peer={ip:'https://login.lisk.io', isConnected:false, height:0, lastConnection:null};
+    var peersArray=['https://login.lisk.io/','https://login01.lisk.io/','https://login02.lisk.io/','https://login03.lisk.io/','https://login04.lisk.io/','https://login05.lisk.io/','https://login06.lisk.io/','https://login07.lisk.io/','https://login08.lisk.io/']
+    var arrayIP = peersArray[Math.floor(Math.random() * peersArray.length)];
+    var peer={ip:arrayIP, isConnected:false, height:0, lastConnection:null};
 
     var connection=$q.defer();
 


### PR DESCRIPTION
Would an array of the official Lisk peers, and randomly selecting one, be a good idea?

Note: It would probably at least be a good idea to check if the connect peer is within (maybe) 5 blocks of the highest block seen on all the official nodes to help verify it's not stuck
